### PR TITLE
Add optional localization parameters

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,11 +3,18 @@
 var split = require('split')
 var unquote = require('unquote')
 var genderize = require('./')
+var args = process.argv.slice(2)
 
 process.stdin
   .pipe(split())
   .on('data', function (name) {
-    genderize(unquote(name), function (err, data) {
+    var options = args.reduce(function (acc, current, index) {
+      var parts = current.split('=')
+      acc[parts[0]] = parts[1]
+      return acc
+    }, {})
+
+    genderize(unquote(name), options, function (err, data) {
       if(err) return console.error(err)
       console.log(JSON.stringify(data))
     })

--- a/example-names.txt
+++ b/example-names.txt
@@ -6,3 +6,4 @@ Finn
 "Jesse"
 Erin
 Doug
+Andrea

--- a/example.js
+++ b/example.js
@@ -7,3 +7,15 @@ genderize('Julia', function (err, obj) {
 genderize.list(['Julia', 'Finn', 'Christian'], function (err, obj) {
   console.log(obj)
 })
+
+genderize('Andrea', function (err, obj) {
+  console.log(obj)
+})
+
+genderize('Andrea', {language_id: 'it'}, function (err, obj) {
+  console.log(obj)
+})
+
+genderize.list(['Julia', 'Finn', 'Christian', 'Andrea'], {language_id: 'it'}, function (err, obj) {
+  console.log(obj)
+})

--- a/index.js
+++ b/index.js
@@ -1,23 +1,35 @@
 var stringify = require('querystring').stringify
 var request = require('request')
 
-function genderize(firstname, cb) {
-  var qs =  stringify({name: firstname})
+function genderize(firstname, options, cb) {
+  var qs = stringify({name: firstname})
+
+  if (typeof options === 'function') {
+    cb = options
+  } else {
+    qs += '&' + stringify(options)
+  }
+
   request('http://api.genderize.io?' + qs, function (err, res, body) {
     if(err) cb(err)
     cb(null, JSON.parse(body))
   })
 }
 
-genderize.list = function (names, cb) {
-
+genderize.list = function (names, options, cb) {
   var values = names.reduce(function (acc, current, index) {
     acc['name[' + index  + ']'] = current
     return acc
   }, {})
-  
+
   var qs = stringify(values)
-  
+
+  if (typeof options === 'function') {
+    cb = options
+  } else {
+    qs += '&' + stringify(options)
+  }
+
   request('http://api.genderize.io?' + qs, function (err, res, body) {
     if(err) cb(err)
     cb(null, JSON.parse(body))

--- a/readme.md
+++ b/readme.md
@@ -13,11 +13,20 @@ var genderize = require('genderize')
 genderize('Julia', function (err, obj) {
   console.log(obj.gender) // outputs 'female'
 }
+
+// optional localization parameters (see https://genderize.io/#localization)
+genderize('Andrea', {language_id: 'it'}, function (err, obj) {
+  console.log(obj.gender) // outputs 'male'
+}
 ```
 
 ### List
 ```js
-genderize.list(['Julia', 'Finn', 'Christian'], function (err, obj) {
+genderize.list(['Julia', 'Finn', 'Christian', 'Andrea'], function (err, obj) {
+  console.log(obj)
+})
+
+genderize.list(['Julia', 'Finn', 'Christian', 'Andrea'], {language_id: 'it'}, function (err, obj) {
   console.log(obj)
 })
 ```
@@ -32,13 +41,21 @@ Given names.txt
 "Julia"
 Florian
 Finn
+Andrea
 ```
 
 This command could result. Note that it doesn't have to be in the correct order.
 
 ```sh
 $ genderize < names.txt
-{"name":"Finn","gender":"male","probability":"1.00","count":29}
-{"name":"Florian","gender":"male","probability":"1.00","count":205}
-{"name":"Julia","gender":"female","probability":"1.00","count":913}
+{"name":"Julia","gender":"female","probability":"0.99","count":2099}
+{"name":"Florian","gender":"male","probability":"1.00","count":469}
+{"name":"Finn","gender":"male","probability":"0.99","count":81}
+{"name":"Andrea","gender":"female","probability":"0.79","count":5623}
+
+$ genderize language_id=it < names.txt
+{"name":"Julia","gender":"female","probability":"1.00","count":7,"language_id":"it"}
+{"name":"Florian","gender":"male","probability":"1.00","count":4,"language_id":"it"}
+{"name":"Finn","gender":null,"language_id":"it"}
+{"name":"Andrea","gender":"male","probability":"0.98","count":1033,"language_id":"it"}
 ```


### PR DESCRIPTION
The API allows for optional localization parameters. They are necessary when having country or language specific genders for a name (see example with `Andrea`).
