### PR TITLE
Use https when contacting genderize.io API

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function genderize(firstname, options, cb) {
     qs += '&' + stringify(options)
   }
 
-  request('http://api.genderize.io?' + qs, function (err, res, body) {
+  request('https://api.genderize.io?' + qs, function (err, res, body) {
     if(err) cb(err)
     cb(null, JSON.parse(body))
   })
@@ -39,7 +39,7 @@ genderize.list = function (names, options, cb) {
     qs += '&' + stringify(options)
   }
 
-  request('http://api.genderize.io?' + qs, function (err, res, body) {
+  request('https://api.genderize.io?' + qs, function (err, res, body) {
     if(err) cb(err)
     cb(null, JSON.parse(body))
   })


### PR DESCRIPTION
Looks like http requests are now being redirected to the main site, which breaks the service completely.